### PR TITLE
Unary rules

### DIFF
--- a/src/edu/berkeley/nlp/PCFGLA/Grammar.java
+++ b/src/edu/berkeley/nlp/PCFGLA/Grammar.java
@@ -226,12 +226,18 @@ public class Grammar implements java.io.Serializable {
 			}
 		}
 		for (int state = 0; state < numStates; state++) {
-			UnaryRule[] unaries = this
-					.getClosedViterbiUnaryRulesByParent(state);
-			for (int r = 0; r < unaries.length; r++) {
-				UnaryRule ur = unaries[r];
+			List<UnaryRule> unaries = this.getUnaryRulesByParent(state);
+			for (int r = 0; r < unaries.size(); r++) {
+			        UnaryRule ur = unaries.get(r);
 				out.print(ur.toString());
 			}
+
+			/*UnaryRule[] unaries = this.getClosedViterbiUnaryRulesByParent(state);
+			for (int r = 0; r < unaries.length; r++) {
+			        UnaryRule ur = unaries[r];
+				out.print(ur.toString());
+			}*/
+
 		}
 		out.flush();
 	}
@@ -1639,7 +1645,7 @@ public class Grammar implements java.io.Serializable {
 				}
 				if (maxSumScore > -1) {
 					resultRsum.setScores2(scoresSum);
-					addUnary(resultRsum);
+					// addUnary(resultRsum);
 					closedSumRulesWithParent[parentState].add(resultRsum);
 					closedSumRulesWithChild[childState].add(resultRsum);
 					closedSumPaths[parentState][childState] = bestSumIntermed;


### PR DESCRIPTION
Grammar.writeData was printing out grammars with rules that sum to more than one. This was apparently for two reasons:

- It was intentionally printing out the max-closed unary rules instead of the real unary rules. But (IMO) it should print out the real rules because it's possible to recompute the max-closed rules from the real rules but not vice versa.
- Grammar.computePairsOfUnaries had a line that was adding the sum-closed unary rules to the set of real unary rules.
